### PR TITLE
docs(readme): clarify authentication password

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Support non-officiel de l'API Kdecole (Mon Bureau Numérique, Skolengo, etc.)
 
 L'accès à l'API requiert une en-tête (header) avec la version de l'application en cours d'utilisation.
 
+Le terme "code" ou "password" ne réfère pas ici à votre mot de passe, mais à un code temporaire généré par votre ENT (dans paramètres > application mobile). C'est comme cela que fonctionne l'authentification à l'API.
+
 Les versions à utiliser lors de la création de l'instance `Kdecole` sont données ci-dessous.
 
 |          Nom de l'ENT         | Version | URL de l'API                                            |

--- a/dist/Kdecole.js
+++ b/dist/Kdecole.js
@@ -63,6 +63,8 @@ var ApiVersion;
  *
  * L'accès à l'API requiert une en-tête (header) avec la version de l'application en cours d'utilisation.
  *
+ * Le terme "code" ou "password" ne réfère pas ici à votre mot de passe, mais à un code temporaire généré par votre ENT (dans paramètres > application mobile). C'est comme cela que fonctionne l'authentification à l'API.
+ *
  * Les versions à utiliser lors de la création de l'instance `Kdecole` sont données ci-dessous.
  *
  * |          Nom de l'ENT         | Version | URL de l'API                                            |

--- a/src/Kdecole.ts
+++ b/src/Kdecole.ts
@@ -83,6 +83,8 @@ export enum ApiVersion {
  *
  * L'accès à l'API requiert une en-tête (header) avec la version de l'application en cours d'utilisation.
  *
+ * Le terme "code" ou "password" ne réfère pas ici à votre mot de passe, mais à un code temporaire généré par votre ENT (dans paramètres > application mobile). C'est comme cela que fonctionne l'authentification à l'API.
+ *
  * Les versions à utiliser lors de la création de l'instance `Kdecole` sont données ci-dessous.
  *
  * |          Nom de l'ENT         | Version | URL de l'API                                            |

--- a/types/Kdecole.d.ts
+++ b/types/Kdecole.d.ts
@@ -52,6 +52,8 @@ export declare enum ApiVersion {
  *
  * L'accès à l'API requiert une en-tête (header) avec la version de l'application en cours d'utilisation.
  *
+ * Le terme "code" ou "password" ne réfère pas ici à votre mot de passe, mais à un code temporaire généré par votre ENT (dans paramètres > application mobile). C'est comme cela que fonctionne l'authentification à l'API.
+ *
  * Les versions à utiliser lors de la création de l'instance `Kdecole` sont données ci-dessous.
  *
  * |          Nom de l'ENT         | Version | URL de l'API                                            |


### PR DESCRIPTION
Bonjour et merci pour ton travail de reverse engineering de l'API, je suis tombé dessus juste après avoir décompilé l'APK et l'avoir fait tourné un petit moment avec Proxyman. Je peux aider si besoin même si tu as l'air de te débrouiller ;)

Il me semble important de préciser que l'authentification fonctionne uniquement via le mdp temporaire généré par le site web et non pas avec les identifiants principaux

<img width="1124" alt="Capture d’écran 2021-07-16 à 15 45 08" src="https://user-images.githubusercontent.com/42497995/125958143-13814085-fbbc-45f3-aba6-2d7192d221be.png">