### PR TITLE
fix(notes): check if listeNotes is defined before foreach

### DIFF
--- a/src/entities/Note/NotesList.ts
+++ b/src/entities/Note/NotesList.ts
@@ -36,6 +36,6 @@ export default class NotesList {
       this.codeEleve = notesList.codeEleve
       this.moduleNotesActif = notesList.moduleNotesActif
       this.nbNotesMax = notesList.nbNotesMax
-      notesList.listeNotes.forEach(note => this.listeNotes.push(new Note(note)))
+      notesList.listeNotes?.forEach(note => this.listeNotes.push(new Note(note)))
     }
 }


### PR DESCRIPTION
Prévient l'erreur `TypeError: Cannot read property 'forEach' of null` si listeNotes est indéfini