### PR TITLE
fix(news): remove parse int for codeEmetteur prop

### DIFF
--- a/src/entities/News/Actualite.ts
+++ b/src/entities/News/Actualite.ts
@@ -1,7 +1,7 @@
 export default class Actualite {
     public type: string
     public auteur: string
-    public codeEmetteur: number
+    public codeEmetteur: string
     public date: Date
     public uid: string
     public titre: string

--- a/src/entities/News/Actualite.ts
+++ b/src/entities/News/Actualite.ts
@@ -19,7 +19,7 @@ export default class Actualite {
       this.errmsg = article.errmsg
       this.type = article.type
       this.auteur = article.auteur
-      this.codeEmetteur = parseInt(article.codeEmetteur)
+      this.codeEmetteur = article.codeEmetteur
       this.titre = article.titre
       this.date = new Date(article.date)
       this.uid = article.uid


### PR DESCRIPTION
codeEmetteur peut également être une chaine de caractère sans être un nombre, ce qui retournera NaN dans l'objet final